### PR TITLE
poratable conditional compiling on darwin platform

### DIFF
--- a/configs/pg_config.h
+++ b/configs/pg_config.h
@@ -124,11 +124,15 @@
 
 /* Define to 1 if you have the declaration of `strlcat', and to 0 if you
    don't. */
-#define HAVE_DECL_STRLCAT 0
+#if OS_DARWIN
+#define HAVE_DECL_STRLCAT 1
+#endif
 
 /* Define to 1 if you have the declaration of `strlcpy', and to 0 if you
    don't. */
-#define HAVE_DECL_STRLCPY 0
+#if OS_DARWIN
+#define HAVE_DECL_STRLCPY 1
+#endif
 
 /* Define to 1 if you have the declaration of `sys_siglist', and to 0 if you
    don't. */

--- a/port/strlcpy.c
+++ b/port/strlcpy.c
@@ -32,6 +32,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#if !OS_DARWIN
+
 #include "c.h"
 
 
@@ -69,3 +71,5 @@ strlcpy(char *dst, const char *src, size_t siz)
 
 	return (s - src - 1);		/* count does not include NUL */
 }
+
+#endif


### PR DESCRIPTION
darwin platform already define functions `strlcat` & `strlcpy`.

introduce conditional compiling for portability.