### PR TITLE
fix SSL_ERROR_SYSCALL handling when errno unset

### DIFF
--- a/fe-secure-openssl.c
+++ b/fe-secure-openssl.c
@@ -201,7 +201,7 @@ rloop:
 			 */
 			goto rloop;
 		case SSL_ERROR_SYSCALL:
-			if (n < 0)
+			if (n < 0 && SOCK_ERRNO != 0)
 			{
 				result_errno = SOCK_ERRNO;
 				if (result_errno == EPIPE ||
@@ -309,7 +309,12 @@ pgtls_write(PGconn *conn, const void *ptr, size_t len)
 			n = 0;
 			break;
 		case SSL_ERROR_SYSCALL:
-			if (n < 0)
+			/*
+			 * If errno is still zero then assume it's a read EOF situation,
+			 * and report EOF.  (This seems possible because SSL_write can
+			 * also do reads.)
+			 */
+			if (n < 0 && SOCK_ERRNO != 0)
 			{
 				result_errno = SOCK_ERRNO;
 				if (result_errno == EPIPE || result_errno == ECONNRESET)
@@ -1314,6 +1319,7 @@ open_client_SSL(PGconn *conn)
 {
 	int			r;
 
+	SOCK_ERRNO_SET(0);
 	ERR_clear_error();
 	r = SSL_connect(conn->ssl);
 	if (r <= 0)
@@ -1334,7 +1340,7 @@ open_client_SSL(PGconn *conn)
 				{
 					char		sebuf[PG_STRERROR_R_BUFLEN];
 
-					if (r == -1)
+					if (r == -1 && SOCK_ERRNO != 0)
 						appendPQExpBuffer(&conn->errorMessage,
 										  libpq_gettext("SSL SYSCALL error: %s\n"),
 										  SOCK_STRERROR(SOCK_ERRNO, sebuf, sizeof(sebuf)));

--- a/fe-secure.c
+++ b/fe-secure.c
@@ -235,6 +235,8 @@ pqsecure_raw_read(PGconn *conn, void *ptr, size_t len)
 	int			result_errno = 0;
 	char		sebuf[PG_STRERROR_R_BUFLEN];
 
+	SOCK_ERRNO_SET(0);
+
 	n = recv(conn->sock, ptr, len, 0);
 
 	if (n < 0)
@@ -260,6 +262,11 @@ pqsecure_raw_read(PGconn *conn, void *ptr, size_t len)
 									 libpq_gettext("server closed the connection unexpectedly\n"
 												   "\tThis probably means the server terminated abnormally\n"
 												   "\tbefore or while processing the request.\n"));
+				break;
+
+			case 0:
+				/* If errno didn't get set, treat it as regular EOF */
+				n = 0;
 				break;
 
 			default:


### PR DESCRIPTION
upstream fix https://github.com/postgres/postgres/commit/0a5c46a7a488f2f4260a90843bb9de6c584c7f4e

Fixes https://github.com/ClickHouse/ClickHouse/issues/67069